### PR TITLE
Modified tags in Push to Docker Hub job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,4 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: express_app_from_docker_tutorial
+          tags: fogstone666/express_app_from_docker_tutorial


### PR DESCRIPTION
Changed tags in job "Push to Docker Hub" from express_app_from_docker_tutorial to fogstone666/express_app_from_docker_tutorial for proper repo naming.